### PR TITLE
grub-stub: GRUB-bootable Multiboot2 kernel stub

### DIFF
--- a/grub-stub/.cargo/config.toml
+++ b/grub-stub/.cargo/config.toml
@@ -1,0 +1,7 @@
+[build]
+target = "x86_64-grub.json"
+
+[unstable]
+build-std = ["core", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]
+json-target-spec = true

--- a/grub-stub/.gitignore
+++ b/grub-stub/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/grub-stub/Cargo.toml
+++ b/grub-stub/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "grub-stub"
+version = "0.1.0"
+edition = "2021"
+description = "Silent-Breath-Online minimal Multiboot2 kernel stub bootable by GRUB"
+
+[dependencies]
+
+[[bin]]
+name = "grub-stub"
+path = "src/main.rs"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true
+codegen-units = 1
+
+# Standalone crate; not part of the parent Silent-Breath-Online workspace.
+[workspace]

--- a/grub-stub/README.md
+++ b/grub-stub/README.md
@@ -1,0 +1,133 @@
+# grub-stub
+
+A minimal, GRUB-bootable Linux-style kernel stub for Silent-Breath-Online.
+
+GRUB boots this image via the Multiboot2 protocol. The stub takes the CPU
+from 32-bit protected mode all the way into 64-bit long mode and then hands
+control to a Rust `kernel_main` function, which is where you start writing
+the rest of your kernel.
+
+```
+[ GRUB ]                            (BIOS / UEFI loads grub.cfg, picks menu entry)
+   |
+   | Multiboot2 protocol: jumps to _start in 32-bit protected mode
+   | eax = 0x36d76289, ebx = phys ptr to multiboot info
+   v
+[ src/boot.S : 32-bit ]             (verify magic, zero BSS, build page tables,
+   |                                 enable PAE/LME/PG, load 64-bit GDT)
+   |
+   | far jmp 0x08:long_mode_start
+   v
+[ src/boot.S : 64-bit ]             (reload segments, enable OSFXSR, set rsp,
+   |                                 pass multiboot info ptr in rdi)
+   |
+   | call kernel_main
+   v
+[ src/main.rs ]                     (Rust no_std no_main; VGA + COM1 output)
+```
+
+## Layout
+
+| Path             | Role                                                       |
+|------------------|------------------------------------------------------------|
+| `src/boot.S`     | Multiboot2 header + 32→64-bit transition (NASM, ELF64)     |
+| `src/main.rs`    | `#[no_mangle] kernel_main(multiboot_info_phys: u64)`       |
+| `linker.ld`      | Places `.boot` first at 1 MiB, then text/rodata/data/bss   |
+| `build.rs`       | Runs NASM, packs `boot.o` into a static lib, links it in   |
+| `x86_64-grub.json` | Custom kernel target (static reloc, kernel code model)   |
+| `grub.cfg`       | GRUB menu entry that boots the kernel via `multiboot2`     |
+| `build-iso.sh`   | One-shot build: kernel → multiboot check → ISO via xorriso |
+
+## Prerequisites
+
+- `cargo` + `rustc` nightly (the `rust-toolchain.toml` at the repo root pins it)
+- `rust-src` and `llvm-tools-preview` components (build-std)
+- `nasm` (assembles `boot.S`)
+- `grub-mkrescue` + `xorriso` + `mtools` (builds the ISO)
+- `qemu-system-x86_64` (to test it)
+
+On Debian/Ubuntu:
+
+```
+apt-get install nasm grub-pc-bin grub-common xorriso mtools qemu-system-x86
+rustup component add rust-src llvm-tools-preview --toolchain nightly
+```
+
+## Build
+
+```
+cd grub-stub
+./build-iso.sh           # produces target/grub-stub.iso
+```
+
+The script:
+
+1. `cargo +nightly build --release` (uses `build-std`, custom target)
+2. `grub-file --is-x86-multiboot2` (sanity-checks the ELF header)
+3. Stages `target/iso/boot/{grub-stub, grub/grub.cfg}`
+4. `grub-mkrescue` produces `target/grub-stub.iso`
+
+## Run
+
+```
+qemu-system-x86_64 -cdrom target/grub-stub.iso -serial stdio -display none -no-reboot
+```
+
+You should see, on the serial console:
+
+```
+Silent-Breath GRUB stub: long mode reached
+Multiboot2 info @ 0x00000000001XXXXX
+CR3 = 0x0000000000104000
+Identity map: 0..1 GiB (2 MiB pages)
+Stub halting. Replace `kernel_main` to extend.
+```
+
+The same banner is also written to the VGA text buffer at `0xb8000`, which is
+what you see if you boot on real hardware or omit `-display none`.
+
+## State at `kernel_main`
+
+When Rust takes over:
+
+- CPU mode: 64-bit long mode, CPL 0, interrupts disabled
+- Paging: 4-level, identity map of `[0, 1 GiB)` via 2 MiB huge pages
+- `CR4`: PAE | OSFXSR | OSXMMEXCPT (so SSE2 is legal — the SysV ABI needs it)
+- `CR0`: PE | MP | NE | WP | PG
+- `EFER`: LME | LMA
+- GDT: flat 64-bit (selector `0x08` code, `0x10` data); IDT not yet loaded
+- `rsp`: top of a 16 KiB boot stack inside `.bss`
+- `rdi`: physical address of the Multiboot2 information structure
+
+What the stub does **not** do (left for you to add):
+
+- Parse the Multiboot2 info tags (memory map, framebuffer, modules…)
+- Install an IDT / interrupt handlers
+- Set up a real frame allocator or kernel heap
+- Bring up the APs / SMP
+
+## Extending
+
+Most kernel work goes in `src/main.rs`. The function signature is:
+
+```rust
+#[no_mangle]
+pub extern "C" fn kernel_main(multiboot_info_phys: u64) -> !;
+```
+
+If you add more `.S` files, list them in `build.rs` and add their objects to
+the static archive. If you change segment layout or the load address, update
+`linker.ld` and the page-table setup in `boot.S` so they keep agreeing.
+
+## Hardware notes
+
+The stub itself runs on any x86_64 machine, but if you want to share state
+with the rest of Silent-Breath-Online's i9-12900K-specific cache-coherency
+code (`baremetal-abi/`), keep these points in mind:
+
+- This stub uses `code-model=kernel` (kernel in the upper canonical half is
+  not currently set up; we run identity-mapped at 1 MiB). Switch to a
+  higher-half mapping before linking against `i9-12900k-baremetal-abi` if you
+  want to share its address-space assumptions.
+- The MESI/coherency runtime in `baremetal-abi/src` assumes a 16-core hybrid
+  topology; the stub is single-CPU until you add AP bring-up.

--- a/grub-stub/build-iso.sh
+++ b/grub-stub/build-iso.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build the GRUB-bootable ISO for the Silent-Breath GRUB stub.
+#
+# Requires: cargo (nightly), nasm, grub-mkrescue, xorriso, mtools.
+# Optional: qemu-system-x86_64 (for the `run` subcommand below).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+KERNEL_TARGET="x86_64-grub"
+KERNEL_PROFILE="${KERNEL_PROFILE:-release}"
+KERNEL_BIN="target/${KERNEL_TARGET}/${KERNEL_PROFILE}/grub-stub"
+ISO_DIR="target/iso"
+ISO_OUT="target/grub-stub.iso"
+
+case "${KERNEL_PROFILE}" in
+    release) CARGO_FLAGS="--release" ;;
+    debug)   CARGO_FLAGS="" ;;
+    *) echo "KERNEL_PROFILE must be 'release' or 'debug'" >&2; exit 1 ;;
+esac
+
+echo "==> Building kernel ($KERNEL_PROFILE)"
+cargo +nightly build $CARGO_FLAGS
+
+if [[ ! -f "$KERNEL_BIN" ]]; then
+    echo "Kernel binary not found at $KERNEL_BIN" >&2
+    exit 1
+fi
+
+echo "==> Verifying Multiboot2 header"
+if ! grub-file --is-x86-multiboot2 "$KERNEL_BIN"; then
+    echo "ERROR: $KERNEL_BIN does not contain a valid Multiboot2 header" >&2
+    exit 1
+fi
+
+echo "==> Staging ISO tree at $ISO_DIR"
+rm -rf "$ISO_DIR"
+mkdir -p "$ISO_DIR/boot/grub"
+cp "$KERNEL_BIN" "$ISO_DIR/boot/grub-stub"
+cp grub.cfg "$ISO_DIR/boot/grub/grub.cfg"
+
+echo "==> Producing ISO at $ISO_OUT"
+grub-mkrescue -o "$ISO_OUT" "$ISO_DIR" >/dev/null 2>&1 \
+    || grub-mkrescue -o "$ISO_OUT" "$ISO_DIR"
+
+echo
+echo "Done."
+echo "  Kernel: $KERNEL_BIN"
+echo "  ISO:    $ISO_OUT"
+echo
+echo "Boot in QEMU (serial mirrored to stdio):"
+echo "  qemu-system-x86_64 -cdrom $ISO_OUT -serial stdio -display none -no-reboot"

--- a/grub-stub/build.rs
+++ b/grub-stub/build.rs
@@ -1,0 +1,47 @@
+//! Assembles `src/boot.S` with NASM into a static archive that Cargo then
+//! links into the kernel binary, and forwards the custom linker script.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let asm_src = crate_dir.join("src/boot.S");
+    let asm_obj = out_dir.join("boot.o");
+    let lib_path = out_dir.join("libboot.a");
+    let linker_script = crate_dir.join("linker.ld");
+
+    println!("cargo:rerun-if-changed=src/boot.S");
+    println!("cargo:rerun-if-changed=linker.ld");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let nasm_status = Command::new("nasm")
+        .arg("-f")
+        .arg("elf64")
+        .arg("-o")
+        .arg(&asm_obj)
+        .arg(&asm_src)
+        .status()
+        .expect("failed to invoke nasm; install with `apt-get install nasm`");
+    assert!(nasm_status.success(), "nasm failed to assemble boot.S");
+
+    let _ = std::fs::remove_file(&lib_path);
+    let ar_status = Command::new("ar")
+        .arg("crus")
+        .arg(&lib_path)
+        .arg(&asm_obj)
+        .status()
+        .expect("failed to invoke ar");
+    assert!(ar_status.success(), "ar failed to create libboot.a");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=boot");
+    println!("cargo:rustc-link-arg-bin=grub-stub=-T{}", linker_script.display());
+    println!("cargo:rustc-link-arg-bin=grub-stub=-nostdlib");
+    println!("cargo:rustc-link-arg-bin=grub-stub=-static");
+    println!("cargo:rustc-link-arg-bin=grub-stub=--no-dynamic-linker");
+    println!("cargo:rustc-link-arg-bin=grub-stub=-zmax-page-size=0x1000");
+}

--- a/grub-stub/grub.cfg
+++ b/grub-stub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "Silent-Breath GRUB stub" {
+    multiboot2 /boot/grub-stub
+    boot
+}

--- a/grub-stub/linker.ld
+++ b/grub-stub/linker.ld
@@ -1,0 +1,51 @@
+/*
+ * Silent-Breath-Online :: GRUB stub linker script
+ *
+ * GRUB loads the kernel image at 1 MiB. The Multiboot2 header must live in
+ * the first 32 KiB of the file, so we place .multiboot_header at the very
+ * start. Code, rodata, data, and bss follow with 4 KiB alignment.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 1M;
+
+    .boot ALIGN(4K) :
+    {
+        KEEP(*(.multiboot_header))
+    }
+
+    .text ALIGN(4K) :
+    {
+        *(.text .text.*)
+    }
+
+    .rodata ALIGN(4K) :
+    {
+        *(.rodata .rodata.*)
+    }
+
+    .data ALIGN(4K) :
+    {
+        *(.data .data.*)
+    }
+
+    .bss ALIGN(4K) :
+    {
+        __bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(8);
+        __bss_end = .;
+    }
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+        *(.note .note.*)
+        *(.comment)
+    }
+}

--- a/grub-stub/src/boot.S
+++ b/grub-stub/src/boot.S
@@ -1,0 +1,190 @@
+; ============================================================================
+; Silent-Breath-Online :: GRUB-bootable Multiboot2 stub
+;
+; GRUB hands control to `_start` in 32-bit protected mode with paging off,
+; eax = 0x36d76289 (multiboot2 magic), ebx = physical address of boot info.
+;
+; This stub:
+;   1. Validates the multiboot2 magic.
+;   2. Zeroes BSS so page tables / stack start clean.
+;   3. Builds an identity-mapped 1 GiB page hierarchy with 2 MiB pages.
+;   4. Enables PAE, sets EFER.LME, enables CR0.PG -> long mode active.
+;   5. Loads a flat 64-bit GDT and far-jumps to 64-bit code.
+;   6. Calls Rust `kernel_main(multiboot_info_phys: u64)`.
+; ============================================================================
+
+bits 32
+
+global _start
+extern kernel_main
+extern __bss_start
+extern __bss_end
+
+MULTIBOOT2_MAGIC          equ 0xe85250d6
+MULTIBOOT2_BOOTLOADER_MAGIC equ 0x36d76289
+MULTIBOOT2_ARCH_I386      equ 0
+
+; ----------------------------------------------------------------------------
+; Multiboot2 header (must live in the first 32 KiB of the file, 8-byte aligned)
+; ----------------------------------------------------------------------------
+section .multiboot_header
+align 8
+header_start:
+    dd MULTIBOOT2_MAGIC
+    dd MULTIBOOT2_ARCH_I386
+    dd header_end - header_start
+    dd 0x100000000 - (MULTIBOOT2_MAGIC + MULTIBOOT2_ARCH_I386 + (header_end - header_start))
+
+    ; End tag (type=0, flags=0, size=8)
+    align 8
+    dw 0
+    dw 0
+    dd 8
+header_end:
+
+; ----------------------------------------------------------------------------
+; BSS: page tables and boot stack
+; ----------------------------------------------------------------------------
+section .bss
+align 4096
+p4_table:
+    resb 4096
+p3_table:
+    resb 4096
+p2_table:
+    resb 4096
+
+align 16
+stack_bottom:
+    resb 16384            ; 16 KiB boot stack
+stack_top:
+
+; ----------------------------------------------------------------------------
+; Read-only data: 64-bit GDT
+; ----------------------------------------------------------------------------
+section .rodata
+align 8
+gdt64:
+    dq 0                                              ; null
+.code_seg: equ $ - gdt64
+    dq (1 << 43) | (1 << 44) | (1 << 47) | (1 << 53)  ; exec | code/data | present | 64-bit
+.data_seg: equ $ - gdt64
+    dq (1 << 44) | (1 << 47) | (1 << 41)              ; code/data | present | writable
+.pointer:
+    dw $ - gdt64 - 1
+    dq gdt64
+
+; ----------------------------------------------------------------------------
+; 32-bit boot code
+; ----------------------------------------------------------------------------
+section .text
+_start:
+    cli
+
+    ; Verify multiboot2 bootloader magic.
+    cmp eax, MULTIBOOT2_BOOTLOADER_MAGIC
+    jne .hang32
+
+    ; Preserve multiboot info pointer across BSS zero (ebp survives stosd).
+    mov ebp, ebx
+
+    ; Zero BSS: page tables and stack memory must start at 0.
+    mov edi, __bss_start
+    mov ecx, __bss_end
+    sub ecx, edi
+    add ecx, 3
+    shr ecx, 2                ; round up to dwords
+    xor eax, eax
+    rep stosd
+
+    ; Restore multiboot info ptr (BSS storage is now zeroed).
+    mov [multiboot_info_addr], ebp
+
+    ; Set up boot stack.
+    mov esp, stack_top
+
+    ; ------------------------------------------------------------------
+    ; Build identity-mapped page tables: PML4[0] -> PDPT[0] -> PD (1 GiB)
+    ; ------------------------------------------------------------------
+    mov eax, p3_table
+    or  eax, 0b11             ; PRESENT | WRITABLE
+    mov [p4_table], eax
+
+    mov eax, p2_table
+    or  eax, 0b11             ; PRESENT | WRITABLE
+    mov [p3_table], eax
+
+    xor ecx, ecx              ; index 0..511
+.fill_pd:
+    mov eax, 0x200000         ; 2 MiB
+    mul ecx                   ; eax = ecx * 2 MiB (edx clobbered, ok)
+    or  eax, 0b10000011       ; PRESENT | WRITABLE | PAGE_SIZE (huge)
+    mov [p2_table + ecx*8], eax
+    inc ecx
+    cmp ecx, 512
+    jne .fill_pd
+
+    ; Load CR3 with PML4 physical address.
+    mov eax, p4_table
+    mov cr3, eax
+
+    ; Enable PAE (bit 5), OSFXSR (bit 9), OSXMMEXCPT (bit 10).
+    ; OSFXSR is required before any SSE instructions; the x86_64 SysV ABI
+    ; (and therefore rustc-generated code) uses XMM registers freely.
+    mov eax, cr4
+    or  eax, (1 << 5) | (1 << 9) | (1 << 10)
+    mov cr4, eax
+
+    ; Enable long mode (EFER.LME).
+    mov ecx, 0xC0000080
+    rdmsr
+    or  eax, 1 << 8
+    wrmsr
+
+    ; Enable paging (CR0.PG) and write-protect (CR0.WP).
+    mov eax, cr0
+    or  eax, (1 << 31) | (1 << 16)
+    mov cr0, eax
+
+    ; CPU is now in IA-32e compatibility mode. Load 64-bit GDT and jump.
+    lgdt [gdt64.pointer]
+    jmp gdt64.code_seg:long_mode_start
+
+.hang32:
+    hlt
+    jmp .hang32
+
+; ----------------------------------------------------------------------------
+; 64-bit code
+; ----------------------------------------------------------------------------
+bits 64
+long_mode_start:
+    ; Reload data segment registers with the data selector (0 also legal in
+    ; 64-bit mode, but a real selector is friendlier to debuggers).
+    mov ax, gdt64.data_seg
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+
+    ; Re-establish the stack with a 64-bit pointer.
+    mov rsp, stack_top
+
+    ; Load multiboot info physical address (zero-extended via .bss reservation).
+    mov rdi, [multiboot_info_addr]
+
+    call kernel_main
+
+.hang64:
+    cli
+    hlt
+    jmp .hang64
+
+; ----------------------------------------------------------------------------
+; Storage for the multiboot info pointer that survives BSS zeroing.
+; ----------------------------------------------------------------------------
+section .bss
+align 8
+multiboot_info_addr:
+    resq 1

--- a/grub-stub/src/main.rs
+++ b/grub-stub/src/main.rs
@@ -1,0 +1,173 @@
+//! Silent-Breath-Online :: GRUB-bootable Linux-style stub.
+//!
+//! Entry from `boot.S` once the CPU is in 64-bit long mode. We have:
+//!   - Identity-mapped first 1 GiB
+//!   - 16 KiB boot stack
+//!   - Interrupts disabled, no IDT installed
+//!   - Multiboot2 info pointer in `multiboot_info_phys`
+//!
+//! This stub prints a banner to VGA text mode and the COM1 serial port,
+//! then halts. It is the launching point for the rest of the kernel.
+
+#![no_std]
+#![no_main]
+
+use core::arch::asm;
+use core::fmt::{self, Write};
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+const COM1: u16 = 0x3F8;
+const VGA_BUFFER: *mut u16 = 0xb8000 as *mut u16;
+const VGA_WIDTH: usize = 80;
+const VGA_HEIGHT: usize = 25;
+
+#[no_mangle]
+pub extern "C" fn kernel_main(multiboot_info_phys: u64) -> ! {
+    unsafe { serial_init() };
+
+    let mut con = Console::new();
+    let _ = writeln!(con, "Silent-Breath GRUB stub: long mode reached");
+    let _ = writeln!(con, "Multiboot2 info @ {:#018x}", multiboot_info_phys);
+    let _ = writeln!(con, "CR3 = {:#018x}", read_cr3());
+    let _ = writeln!(con, "Identity map: 0..1 GiB (2 MiB pages)");
+    let _ = writeln!(con, "Stub halting. Replace `kernel_main` to extend.");
+
+    halt_forever();
+}
+
+// ---------------------------------------------------------------------------
+// Console: writes to both VGA text buffer and COM1 serial.
+// ---------------------------------------------------------------------------
+
+struct Console {
+    vga_row: usize,
+    vga_col: usize,
+}
+
+impl Console {
+    const fn new() -> Self {
+        Self { vga_row: 0, vga_col: 0 }
+    }
+
+    fn put_byte(&mut self, byte: u8) {
+        unsafe { serial_write_byte(byte) };
+        self.vga_put_byte(byte);
+    }
+
+    fn vga_put_byte(&mut self, byte: u8) {
+        match byte {
+            b'\n' => self.vga_newline(),
+            b'\r' => self.vga_col = 0,
+            _ => {
+                if self.vga_col >= VGA_WIDTH {
+                    self.vga_newline();
+                }
+                let entry = 0x0f00u16 | (byte as u16);
+                let idx = self.vga_row * VGA_WIDTH + self.vga_col;
+                unsafe { VGA_BUFFER.add(idx).write_volatile(entry) };
+                self.vga_col += 1;
+            }
+        }
+    }
+
+    fn vga_newline(&mut self) {
+        self.vga_col = 0;
+        if self.vga_row + 1 < VGA_HEIGHT {
+            self.vga_row += 1;
+        } else {
+            self.vga_scroll();
+        }
+    }
+
+    fn vga_scroll(&mut self) {
+        for row in 1..VGA_HEIGHT {
+            for col in 0..VGA_WIDTH {
+                unsafe {
+                    let src = VGA_BUFFER.add(row * VGA_WIDTH + col).read_volatile();
+                    VGA_BUFFER.add((row - 1) * VGA_WIDTH + col).write_volatile(src);
+                }
+            }
+        }
+        for col in 0..VGA_WIDTH {
+            unsafe {
+                VGA_BUFFER
+                    .add((VGA_HEIGHT - 1) * VGA_WIDTH + col)
+                    .write_volatile(0x0f20);
+            }
+        }
+        self.vga_col = 0;
+    }
+}
+
+impl Write for Console {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for byte in s.bytes() {
+            self.put_byte(byte);
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serial port (COM1, 38400 8N1).
+// ---------------------------------------------------------------------------
+
+static SERIAL_READY: AtomicU8 = AtomicU8::new(0);
+
+unsafe fn serial_init() {
+    if SERIAL_READY.swap(1, Ordering::AcqRel) != 0 {
+        return;
+    }
+    outb(COM1 + 1, 0x00); // disable interrupts
+    outb(COM1 + 3, 0x80); // enable DLAB
+    outb(COM1, 0x03);     // divisor low (38400 baud)
+    outb(COM1 + 1, 0x00); // divisor high
+    outb(COM1 + 3, 0x03); // 8 bits, no parity, one stop
+    outb(COM1 + 2, 0xC7); // FIFO, clear, 14-byte threshold
+    outb(COM1 + 4, 0x0B); // IRQs enabled, RTS/DSR set
+}
+
+unsafe fn serial_write_byte(byte: u8) {
+    while (inb(COM1 + 5) & 0x20) == 0 {}
+    outb(COM1, byte);
+    if byte == b'\n' {
+        while (inb(COM1 + 5) & 0x20) == 0 {}
+        outb(COM1, b'\r');
+    }
+}
+
+#[inline(always)]
+unsafe fn outb(port: u16, val: u8) {
+    asm!("out dx, al", in("dx") port, in("al") val, options(nomem, nostack, preserves_flags));
+}
+
+#[inline(always)]
+unsafe fn inb(port: u16) -> u8 {
+    let val: u8;
+    asm!("in al, dx", out("al") val, in("dx") port, options(nomem, nostack, preserves_flags));
+    val
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers.
+// ---------------------------------------------------------------------------
+
+fn read_cr3() -> u64 {
+    let value: u64;
+    unsafe { asm!("mov {}, cr3", out(reg) value, options(nomem, nostack, preserves_flags)) };
+    value
+}
+
+fn halt_forever() -> ! {
+    loop {
+        unsafe { asm!("cli; hlt", options(nomem, nostack)) };
+    }
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    let mut con = Console::new();
+    let _ = writeln!(con, "\n!!! KERNEL PANIC: {info}");
+    halt_forever()
+}

--- a/grub-stub/x86_64-grub.json
+++ b/grub-stub/x86_64-grub.json
@@ -1,0 +1,20 @@
+{
+  "llvm-target": "x86_64-unknown-none",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64",
+  "target-endian": "little",
+  "target-pointer-width": 64,
+  "target-c-int-width": 32,
+  "os": "none",
+  "linker-flavor": "ld.lld",
+  "linker": "rust-lld",
+  "executables": true,
+  "features": "+sse,+sse2,-avx,-avx2,-avx512f",
+  "disable-redzone": true,
+  "panic-strategy": "abort",
+  "code-model": "kernel",
+  "relocation-model": "static",
+  "metadata": {
+    "description": "Silent-Breath-Online GRUB-bootable Multiboot2 kernel target"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `grub-stub/`, a self-contained crate that produces a GRUB-bootable
Multiboot2 kernel image. GRUB hands off to a 32-bit asm entry, which sets up
identity-mapped paging, transitions to 64-bit long mode, and calls a Rust
`kernel_main` — the launching point for extending into a full kernel.

This is the "build my own Linux stub at GRUB level" piece, intentionally kept
separate from the existing `baremetal-abi/` crate (which uses the
`bootloader_api` boot protocol, not Multiboot2).

### What's in it

| Path | Role |
|---|---|
| `grub-stub/src/boot.S` | Multiboot2 header, 32-bit entry, page tables, 32→64-bit transition (NASM, ELF64) |
| `grub-stub/src/main.rs` | `#[no_mangle] kernel_main(multiboot_info_phys: u64)` with VGA + COM1 output |
| `grub-stub/linker.ld` | Places `.boot` first at 1 MiB, then text/rodata/data/bss |
| `grub-stub/build.rs` | Runs NASM, packs `boot.o` into a static lib, forwards the linker script |
| `grub-stub/x86_64-grub.json` | Custom kernel target (static reloc, `code-model=kernel`) |
| `grub-stub/grub.cfg` | GRUB menu entry that boots the kernel via `multiboot2` |
| `grub-stub/build-iso.sh` | One-shot: `cargo build` → `grub-file` check → `grub-mkrescue` ISO |
| `grub-stub/README.md` | Architecture diagram, prereqs, build/run instructions |

### State at `kernel_main`

- 64-bit long mode, CPL 0, interrupts disabled
- 4-level paging, identity map of `[0, 1 GiB)` via 2 MiB huge pages
- `CR4`: PAE | OSFXSR | OSXMMEXCPT (SSE2 legal — SysV ABI requires it)
- `CR0`: PE | MP | NE | WP | PG; `EFER`: LME | LMA
- 16 KiB boot stack in `.bss`; multiboot info physical pointer in `rdi`

## Test plan

- [x] `cargo +nightly build --release` produces `target/x86_64-grub/release/grub-stub`
- [x] `grub-file --is-x86-multiboot2` accepts the ELF
- [x] `grub-mkrescue` produces a 5 MB bootable ISO
- [x] QEMU boots the ISO end-to-end and the Rust banner appears on COM1:
  ```
  Silent-Breath GRUB stub: long mode reached
  Multiboot2 info @ 0x0000000000100740
  CR3 = 0x0000000000104000
  Identity map: 0..1 GiB (2 MiB pages)
  Stub halting. Replace `kernel_main` to extend.
  ```
- [ ] Boot on real hardware (not validated in this PR)

## Notes for review

- During bring-up the first boot triple-faulted with `#UD` on `xorps xmm0,xmm0` because rustc emits SSE2 (SysV ABI requires it) but `CR4.OSFXSR` was off. Fix is in `boot.S` — `(1<<9) | (1<<10)` set alongside `CR4.PAE`.
- BSS (page tables + stack) is explicitly zeroed at boot since Multiboot loaders aren't required to do it. The multiboot info pointer is preserved in `ebp` across the zero loop and saved into `.bss` storage afterwards.
- The crate is standalone (`[workspace]` table in its own `Cargo.toml`) to avoid coupling its target spec / build-std / nightly requirements to the parent project.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKVVjK1coFGsi6s6RaZkgy)_