### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Prepares the Rust nightly toolchain so `cargo check`, `cargo test --lib`,
+# clippy and rustfmt work out of the box for the silent-breath-mmio crate.
+set -euo pipefail
+
+# Only run in the remote (web) environment; local machines already have a setup.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# rust-toolchain.toml pins nightly; make sure it is installed and is the
+# active default, then add the components the project needs:
+#   - clippy / rustfmt : linting and formatting (used in validation)
+#   - rust-src         : required by baremetal-abi's build-std (.cargo/config.toml)
+rustup toolchain install nightly --profile minimal --no-self-update
+rustup default nightly
+rustup component add clippy rustfmt rust-src
+
+# Pre-download crate dependencies so the first build is offline-fast.
+cargo fetch --locked 2>/dev/null || cargo fetch
+
+# Warm the build cache for the root crate (mirrors CI: `cargo check --all-targets`).
+# The container filesystem is cached after the hook completes, so this makes the
+# first in-session `cargo test` / `cargo clippy` near-instant.
+cargo check --all-targets
+
+echo "session-start: Rust nightly toolchain + components ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a `SessionStart` hook so Claude Code on the web sessions come up with a working Rust toolchain — the "Run setup script" step was previously empty (no setup script configured), leaving each fresh container to lazily fetch the toolchain/components on demand.

## Changes

- **`.claude/hooks/session-start.sh`** — runs only in the remote/web env (`$CLAUDE_CODE_REMOTE`). It:
  - installs the pinned **nightly** toolchain and sets it as default;
  - adds the components the project needs: `clippy`, `rustfmt`, and `rust-src` (the latter is required by `baremetal-abi`'s `build-std` in `.cargo/config.toml`);
  - runs `cargo fetch` to pre-download dependencies;
  - warms the build cache with `cargo check --all-targets` (mirrors CI), so the first in-session `cargo test` / `cargo clippy` is near-instant.
- **`.claude/settings.json`** — registers the hook under `SessionStart`.

## Validation (run locally in the sandbox)

| Check | Result |
| --- | --- |
| Hook executes (`CLAUDE_CODE_REMOTE=true`) | ✅ exit 0, components installed |
| Linter — `cargo clippy --lib` / `rustfmt` | ✅ both run |
| Test — `cargo test --lib` | ✅ passes (175 tests) |

## Notes

- The hook is **synchronous**: it guarantees the toolchain is ready before the session starts (no race conditions), at the cost of slightly slower session startup. Can be switched to async if faster startup is preferred.
- Scope is intentionally limited to the toolchain/lint/test path that CI exercises. The `baremetal-abi` crate currently fails to build for an unrelated reason — recent nightly requires `-Zjson-target-spec` for its custom `.json` target — which is out of scope for this setup hook.

https://claude.ai/code/session_01FKi7Wvam8tJCjtuGgyQGrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKi7Wvam8tJCjtuGgyQGrR)_