### PR TITLE
Fix verified code-review findings across both crates

### DIFF
--- a/baremetal-abi/Cargo.toml
+++ b/baremetal-abi/Cargo.toml
@@ -3,6 +3,10 @@ name = "i9-12900k-baremetal-abi"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Route boot-path logging to the COM1 serial driver
+serial = []
+
 [dependencies]
 # Use the existing Silent-Breath-Online cache coherency system
 silent-breath-mmio = { path = ".." }

--- a/baremetal-abi/src/bin/minimal.rs
+++ b/baremetal-abi/src/bin/minimal.rs
@@ -13,11 +13,11 @@
 extern crate alloc;
 
 use core::alloc::{GlobalAlloc, Layout};
-use core::fmt::Write;
 use bootloader_api::{entry_point, BootInfo};
 use i9_12900k_baremetal_abi::{
-    cpu, performance, CoreType,
+    cpu, performance, serial, CoreType,
     coherency_runtime::CoherencyRuntime,
+    serial::SerialPort,
 };
 
 /// Dummy allocator for bare-metal (fails all allocations)
@@ -37,62 +37,8 @@ unsafe impl GlobalAlloc for DummyAllocator {
 #[global_allocator]
 static ALLOCATOR: DummyAllocator = DummyAllocator;
 
-/// Simple serial port driver (COM1)
-struct SerialPort;
-
-impl SerialPort {
-    const PORT: u16 = 0x3F8; // COM1
-
-    /// Initialize serial port
-    #[allow(dead_code)]
-    unsafe fn init() {
-        use core::arch::asm;
-
-        // Disable interrupts
-        asm!("out dx, al", in("dx") Self::PORT + 1, in("al") 0x00u8, options(nomem, nostack));
-
-        // Enable DLAB
-        asm!("out dx, al", in("dx") Self::PORT + 3, in("al") 0x80u8, options(nomem, nostack));
-
-        // Set divisor to 3 (38400 baud)
-        asm!("out dx, al", in("dx") Self::PORT, in("al") 0x03u8, options(nomem, nostack));
-        asm!("out dx, al", in("dx") Self::PORT + 1, in("al") 0x00u8, options(nomem, nostack));
-
-        // 8N1
-        asm!("out dx, al", in("dx") Self::PORT + 3, in("al") 0x03u8, options(nomem, nostack));
-
-        // Enable FIFO
-        asm!("out dx, al", in("dx") Self::PORT + 2, in("al") 0xC7u8, options(nomem, nostack));
-
-        // Enable IRQs, RTS/DSR
-        asm!("out dx, al", in("dx") Self::PORT + 4, in("al") 0x0Bu8, options(nomem, nostack));
-    }
-
-    /// Write a byte to serial port
-    fn write_byte(byte: u8) {
-        unsafe {
-            use core::arch::asm;
-            // Wait for transmit ready (bit 5 of line status)
-            let mut ready = 0u8;
-            while (ready & 0x20) == 0 {
-                asm!("in al, dx", out("al") ready, in("dx") Self::PORT + 5, options(nomem, nostack));
-            }
-            // Write byte
-            asm!("out dx, al", in("dx") Self::PORT, in("al") byte, options(nomem, nostack));
-        }
-    }
-}
-
-impl Write for SerialPort {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        for byte in s.bytes() {
-            Self::write_byte(byte);
-        }
-        Ok(())
-    }
-}
-
-/// Serial output macro
+/// Serial output macro (COM1 driver shared with the library, see
+/// i9_12900k_baremetal_abi::serial)
 macro_rules! serial_print {
     ($($arg:tt)*) => {{
         #[cfg(not(test))]
@@ -118,6 +64,8 @@ entry_point!(kernel_main);
 fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     // Suppress unused warning
     let _ = boot_info;
+
+    serial::init();
 
     serial_println!("========================================");
     serial_println!("i9-12900K Minimal Bare-Metal Kernel");

--- a/baremetal-abi/src/boot.rs
+++ b/baremetal-abi/src/boot.rs
@@ -2,8 +2,14 @@
 //!
 //! UEFI entry point, kernel initialization, and boot info
 
+use crate::coherency_runtime::CoherencyRuntime;
 use crate::cpu;
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::BootInfo;
+
+/// Kernel-lifetime coherency runtime, initialized once during boot.
+/// Lives in BSS so the initialization in init_cache_coherency() is retained
+/// instead of being dropped at end of scope.
+static mut COHERENCY_RUNTIME: CoherencyRuntime = CoherencyRuntime::new();
 
 /// Main kernel initialization function
 ///
@@ -19,7 +25,7 @@ use bootloader_api::{entry_point, BootInfo};
 pub fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     // Initialize serial output for debugging (if available)
     #[cfg(feature = "serial")]
-    serial::init();
+    crate::serial::init();
 
     log("i9-12900K Bare-Metal Firmware ABI v0.1.0");
     log("Initializing CPU...");
@@ -70,11 +76,9 @@ pub fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 
 /// Initialize cache coherency for hybrid architecture
 fn init_cache_coherency() {
-    use crate::coherency_runtime::CoherencyRuntime;
-
-    let mut runtime = CoherencyRuntime::new();
-
     unsafe {
+        let runtime = coherency_runtime();
+
         // Initialize P-cores (0-7)
         for p_core in 0..8 {
             runtime.init_core(p_core);
@@ -87,6 +91,16 @@ fn init_cache_coherency() {
     }
 
     log("Cache coherency initialized for 16 cores (8P+8E)");
+}
+
+/// Access the boot-initialized coherency runtime
+///
+/// # Safety
+/// The caller must guarantee exclusive access: the kernel is single-threaded
+/// during boot and the kernel loop, and the returned reference must not be
+/// held across a point where another mutable reference is created.
+pub unsafe fn coherency_runtime() -> &'static mut CoherencyRuntime {
+    &mut *core::ptr::addr_of_mut!(COHERENCY_RUNTIME)
 }
 
 /// Kernel main loop
@@ -117,7 +131,7 @@ fn kernel_loop() -> ! {
 fn log(message: &str) {
     // In a real implementation, this would write to serial port or framebuffer
     #[cfg(feature = "serial")]
-    serial::write_str(message);
+    crate::serial::write_line(message);
 
     // For now, just a no-op in release mode
     #[cfg(not(feature = "serial"))]
@@ -126,73 +140,13 @@ fn log(message: &str) {
 
 /// Formatted logging
 fn log_fmt(args: core::fmt::Arguments) {
-    use core::fmt::Write;
-
     #[cfg(feature = "serial")]
     {
-        let mut serial = serial::SerialPort;
+        use core::fmt::Write;
+        let mut serial = crate::serial::SerialPort;
         let _ = serial.write_fmt(args);
     }
 
     #[cfg(not(feature = "serial"))]
     let _ = args;
-}
-
-/// Optional serial port module for debugging
-#[cfg(feature = "serial")]
-mod serial {
-    use core::fmt;
-    use x86_64::instructions::port::Port;
-
-    const SERIAL_IO_PORT: u16 = 0x3F8; // COM1
-
-    pub struct SerialPort;
-
-    pub fn init() {
-        unsafe {
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 1);
-            port.write(0x00); // Disable interrupts
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 3);
-            port.write(0x80); // Enable DLAB
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT);
-            port.write(0x03); // Divisor low byte (38400 baud)
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 1);
-            port.write(0x00); // Divisor high byte
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 3);
-            port.write(0x03); // 8N1
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 2);
-            port.write(0xC7); // Enable FIFO
-
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT + 4);
-            port.write(0x0B); // IRQs enabled, RTS/DSR set
-        }
-    }
-
-    pub fn write_byte(byte: u8) {
-        unsafe {
-            let mut port = Port::<u8>::new(SERIAL_IO_PORT);
-            port.write(byte);
-        }
-    }
-
-    pub fn write_str(s: &str) {
-        for byte in s.bytes() {
-            write_byte(byte);
-        }
-        write_byte(b'\n');
-    }
-
-    impl fmt::Write for SerialPort {
-        fn write_str(&mut self, s: &str) -> fmt::Result {
-            for byte in s.bytes() {
-                write_byte(byte);
-            }
-            Ok(())
-        }
-    }
 }

--- a/baremetal-abi/src/lib.rs
+++ b/baremetal-abi/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cpu;
 pub mod interrupts;
 pub mod memory;
 pub mod performance;
+pub mod serial;
 
 // Re-export Silent-Breath-Online cache coherency system
 pub use silent_breath_mmio::{

--- a/baremetal-abi/src/serial.rs
+++ b/baremetal-abi/src/serial.rs
@@ -1,0 +1,76 @@
+//! Shared COM1 serial driver for the library boot path and kernel binaries
+//!
+//! Both `boot` and the kernel binaries used to carry their own copy of this
+//! UART setup sequence; this module is the single implementation.
+
+use core::fmt;
+use x86_64::instructions::port::Port;
+
+const SERIAL_IO_PORT: u16 = 0x3F8; // COM1
+
+/// Bound on the transmit-ready wait so a wedged UART cannot hang the kernel
+const TX_READY_SPIN_LIMIT: u32 = 100_000;
+
+/// Zero-sized writer over COM1, usable with `core::fmt::Write`
+pub struct SerialPort;
+
+/// Initialize COM1: 38400 baud, 8N1, FIFO enabled
+pub fn init() {
+    unsafe {
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 1);
+        port.write(0x00); // Disable interrupts
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 3);
+        port.write(0x80); // Enable DLAB
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT);
+        port.write(0x03); // Divisor low byte (38400 baud)
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 1);
+        port.write(0x00); // Divisor high byte
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 3);
+        port.write(0x03); // 8N1
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 2);
+        port.write(0xC7); // Enable FIFO
+
+        let mut port = Port::<u8>::new(SERIAL_IO_PORT + 4);
+        port.write(0x0B); // IRQs enabled, RTS/DSR set
+    }
+}
+
+/// Write one byte, waiting (bounded) for the transmit holding register
+pub fn write_byte(byte: u8) {
+    unsafe {
+        let mut line_status = Port::<u8>::new(SERIAL_IO_PORT + 5);
+        let mut spins = 0u32;
+        while line_status.read() & 0x20 == 0 {
+            if spins >= TX_READY_SPIN_LIMIT {
+                break; // UART wedged: drop rather than hang the kernel
+            }
+            spins += 1;
+            core::hint::spin_loop();
+        }
+
+        let mut data = Port::<u8>::new(SERIAL_IO_PORT);
+        data.write(byte);
+    }
+}
+
+/// Write a string followed by a newline
+pub fn write_line(s: &str) {
+    for byte in s.bytes() {
+        write_byte(byte);
+    }
+    write_byte(b'\n');
+}
+
+impl fmt::Write for SerialPort {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for byte in s.bytes() {
+            write_byte(byte);
+        }
+        Ok(())
+    }
+}

--- a/src/cache_coherency.rs
+++ b/src/cache_coherency.rs
@@ -92,11 +92,27 @@ impl L3Directory {
         }
     }
 
+    /// Evict the resident line if a different address aliases to this slot
+    /// (direct-mapped: distinct line addresses share an index, so the tag
+    /// must be compared before the cached state can be trusted)
+    #[inline]
+    fn evict_on_alias(line: &mut CacheLine, line_addr: u64) {
+        if line.get_state() != CacheState::Invalid && line.tag != line_addr {
+            line.force_state(CacheState::Invalid);
+            line.ref_count.store(0, Ordering::Release);
+            line.owner_core = 0xFF;
+        }
+    }
+
     /// Real-Time Traversal: Step 1 - Core 1 reads data (Shared state)
     #[inline]
     pub fn core_read(&mut self, core_id: u8, address: u64) -> Result<&[u8; 64], ()> {
-        let index = (address >> 6) % 1024;
-        let line = &self.lines[index as usize];
+        let line_addr = address >> 6;
+        let index = line_addr % 1024;
+        let line = &mut self.lines[index as usize];
+
+        Self::evict_on_alias(line, line_addr);
+        line.tag = line_addr;
 
         match line.get_state() {
             CacheState::Invalid => {
@@ -124,7 +140,11 @@ impl L3Directory {
     /// Real-Time Traversal: Step 3 - Core 1 writes (Invalidates other cores)
     #[inline]
     pub fn core_write(&mut self, core_id: u8, address: u64) -> Result<&mut [u8; 64], ()> {
-        let index = (address >> 6) % 1024;
+        let line_addr = address >> 6;
+        let index = line_addr % 1024;
+
+        Self::evict_on_alias(&mut self.lines[index as usize], line_addr);
+        self.lines[index as usize].tag = line_addr;
 
         // Get state and owner first, before mutable borrow
         let current_state = self.lines[index as usize].get_state();
@@ -255,6 +275,27 @@ mod tests {
 
         let index = (address >> 6) % 1024;
         assert_eq!(dir.lines[index as usize].get_state(), CacheState::Shared);
+    }
+
+    #[test]
+    fn test_l3_directory_aliased_addresses_do_not_share_state() {
+        let mut dir = L3Directory::new();
+
+        // Two addresses 64 KiB apart alias to the same direct-mapped index
+        let addr_a = 0x40u64;
+        let addr_b = addr_a + 1024 * 64;
+        assert_eq!((addr_a >> 6) % 1024, (addr_b >> 6) % 1024);
+
+        // Core 1 owns addr_a in Modified state
+        dir.core_write(1, addr_a).unwrap();
+        let index = ((addr_a >> 6) % 1024) as usize;
+        assert_eq!(dir.lines[index].get_state(), CacheState::Modified);
+
+        // A read of addr_b must not inherit addr_a's Modified state: the
+        // resident line is evicted and addr_b starts from Invalid -> Shared
+        dir.core_read(2, addr_b).unwrap();
+        assert_eq!(dir.lines[index].get_state(), CacheState::Shared);
+        assert_eq!(dir.lines[index].tag, addr_b >> 6);
     }
 
     #[test]

--- a/src/ecc_handler.rs
+++ b/src/ecc_handler.rs
@@ -28,8 +28,67 @@ pub struct ECCSyndrome {
     pub error_count: u8,
 }
 
+/// Codeword position of each data bit: data bit `d` lives at the
+/// `(d+1)`-th non-power-of-two position in 1..=71. Positions 1, 2, 4, 8,
+/// 16, 32, 64 are reserved for the 7 Hamming parity bits, so a nonzero
+/// syndrome equals the codeword position of a single-bit error and parity
+/// errors are distinguishable from data errors.
+const DATA_POS: [u8; 64] = {
+    let mut tbl = [0u8; 64];
+    let mut pos = 1usize;
+    let mut d = 0usize;
+    while d < 64 {
+        if pos & (pos - 1) != 0 {
+            tbl[d] = pos as u8;
+            d += 1;
+        }
+        pos += 1;
+    }
+    tbl
+};
+
+/// Reverse mapping: codeword position -> data bit index (0xFF for parity
+/// positions and positions outside the codeword).
+const POS_TO_DATA: [u8; 128] = {
+    let mut tbl = [0xFFu8; 128];
+    let mut d = 0usize;
+    while d < 64 {
+        tbl[DATA_POS[d] as usize] = d as u8;
+        d += 1;
+    }
+    tbl
+};
+
+/// Coverage mask for Hamming parity bit `i`: data bits whose codeword
+/// position has bit `i` set. Parity is then one popcount per mask.
+const PARITY_MASKS: [u64; 7] = {
+    let mut masks = [0u64; 7];
+    let mut d = 0usize;
+    while d < 64 {
+        let pos = DATA_POS[d] as usize;
+        let mut i = 0usize;
+        while i < 7 {
+            if pos & (1 << i) != 0 {
+                masks[i] |= 1u64 << d;
+            }
+            i += 1;
+        }
+        d += 1;
+    }
+    masks
+};
+
+/// In the 8-bit parity byte, bits 0-6 are the Hamming parities and bit 7 is
+/// the overall (SECDED) parity over data and the 7 Hamming bits.
+const OVERALL_PARITY_BIT: u8 = 0x80;
+
+/// `ECCSyndrome::error_position` values at or above this denote an error in
+/// the parity byte itself (64 + parity bit index) rather than a data bit.
+pub const PARITY_ERROR_POSITION_BASE: u8 = 64;
+
 /// Hamming Code ECC Implementation
-/// Uses (72,64) Hamming code: 64 data bits + 8 parity bits
+/// Uses (72,64) SECDED Hamming code: 64 data bits + 7 Hamming parity bits
+/// + 1 overall parity bit (single-bit correct, double-bit detect)
 pub struct HammingECC {
     /// Error detection counter
     errors_detected: AtomicU32,
@@ -51,38 +110,45 @@ impl HammingECC {
     pub fn encode(&self, data: u64) -> (u64, u8) {
         let mut parity: u8 = 0;
 
-        // Calculate 8 parity bits
-        for i in 0..8 {
-            let mut bit_count = 0;
-
-            // Count bits that should contribute to this parity bit
-            for j in 0..64 {
-                // Check if bit j should be included in parity i
-                if (j & (1 << i)) != 0 {
-                    if (data >> j) & 1 == 1 {
-                        bit_count += 1;
-                    }
-                }
-            }
-
-            // Set parity bit
-            if bit_count % 2 == 1 {
+        // 7 Hamming parity bits, one popcount per coverage mask
+        for (i, mask) in PARITY_MASKS.iter().enumerate() {
+            if (data & mask).count_ones() & 1 == 1 {
                 parity |= 1 << i;
             }
+        }
+
+        // Overall parity over data + Hamming bits (SECDED)
+        if (data.count_ones() + (parity as u32).count_ones()) & 1 == 1 {
+            parity |= OVERALL_PARITY_BIT;
         }
 
         (data, parity)
     }
 
+    /// Compute the 7-bit Hamming syndrome and the overall-parity check.
+    /// Returns (syndrome, overall_mismatch): syndrome is the codeword
+    /// position of a single-bit error; overall_mismatch distinguishes
+    /// single-bit (true) from double-bit (false) errors when syndrome != 0.
+    fn syndrome(&self, data: u64, parity: u8) -> (u8, bool) {
+        let (_, calculated) = self.encode(data);
+        let syndrome = (calculated ^ parity) & 0x7F;
+
+        // Overall parity over the received codeword: data + received Hamming
+        // bits + received overall bit. Zero when intact or after an even
+        // number of flips.
+        let received_hamming = (parity & 0x7F) as u32;
+        let overall_bit = (parity >> 7) as u32;
+        let overall_mismatch =
+            (data.count_ones() + received_hamming.count_ones() + overall_bit) & 1 == 1;
+
+        (syndrome, overall_mismatch)
+    }
+
     /// Decode and correct data using Hamming ECC
     pub fn decode(&self, data: u64, parity: u8) -> Result<(u64, ECCSyndrome), &'static str> {
-        // Recalculate parity
-        let (_, calculated_parity) = self.encode(data);
+        let (syndrome, overall_mismatch) = self.syndrome(data, parity);
 
-        // XOR to get syndrome
-        let syndrome = calculated_parity ^ parity;
-
-        if syndrome == 0 {
+        if syndrome == 0 && !overall_mismatch {
             // No error
             return Ok((
                 data,
@@ -94,26 +160,42 @@ impl HammingECC {
             ));
         }
 
-        // Count number of bits set in syndrome
-        let error_count = syndrome.count_ones() as u8;
-
-        if error_count == 1 {
-            // Single-bit error in parity (detectable, no correction needed)
+        if syndrome == 0 {
+            // Only the overall parity bit itself flipped; data is intact
             self.errors_detected.fetch_add(1, Ordering::Relaxed);
 
             return Ok((
                 data,
                 ECCSyndrome {
                     error_type: ECCError::SingleBit,
-                    error_position: syndrome.trailing_zeros() as u8,
+                    error_position: PARITY_ERROR_POSITION_BASE + 7,
                     error_count: 1,
                 },
             ));
         }
 
-        // Determine error position from syndrome
-        let error_position = syndrome as u8;
+        if !overall_mismatch {
+            // Nonzero syndrome but overall parity balances: two bits flipped
+            self.errors_detected.fetch_add(1, Ordering::Relaxed);
+            return Err("Double-bit error detected - cannot correct");
+        }
 
+        // Single-bit error at codeword position `syndrome`
+        if syndrome & (syndrome - 1) == 0 {
+            // Power-of-two position: a Hamming parity bit flipped, data intact
+            self.errors_detected.fetch_add(1, Ordering::Relaxed);
+
+            return Ok((
+                data,
+                ECCSyndrome {
+                    error_type: ECCError::SingleBit,
+                    error_position: PARITY_ERROR_POSITION_BASE + syndrome.trailing_zeros() as u8,
+                    error_count: 1,
+                },
+            ));
+        }
+
+        let error_position = POS_TO_DATA[syndrome as usize];
         if error_position < 64 {
             // Single-bit error in data (correctable)
             let corrected_data = data ^ (1u64 << error_position);
@@ -131,7 +213,7 @@ impl HammingECC {
             ));
         }
 
-        // Multi-bit error (not correctable)
+        // Syndrome outside the codeword: multi-bit error (not correctable)
         self.errors_detected.fetch_add(1, Ordering::Relaxed);
 
         Err("Multi-bit error detected - cannot correct")
@@ -139,17 +221,14 @@ impl HammingECC {
 
     /// Verify data integrity without correction
     pub fn verify(&self, data: u64, parity: u8) -> ECCError {
-        let (_, calculated_parity) = self.encode(data);
-        let syndrome = calculated_parity ^ parity;
+        let (syndrome, overall_mismatch) = self.syndrome(data, parity);
 
-        if syndrome == 0 {
+        if syndrome == 0 && !overall_mismatch {
             ECCError::NoError
-        } else if syndrome.count_ones() == 1 {
+        } else if overall_mismatch {
             ECCError::SingleBit
-        } else if syndrome.count_ones() == 2 {
-            ECCError::DoubleBit
         } else {
-            ECCError::MultiBit
+            ECCError::DoubleBit
         }
     }
 
@@ -607,10 +686,84 @@ mod tests {
         let result = hamming.decode(encoded, bad_parity);
 
         // Should detect error but not be able to correct
-        if result.is_err() {
-            assert_eq!(result.unwrap_err(), "Multi-bit error detected - cannot correct");
-            let (detected, _) = hamming.get_error_stats();
+        assert!(result.is_err());
+        let (detected, corrected) = hamming.get_error_stats();
+        assert_eq!(detected, 1);
+        assert_eq!(corrected, 0);
+    }
+
+    #[test]
+    fn test_hamming_corrects_power_of_two_positions() {
+        // Regression: data-bit errors at power-of-two positions used to be
+        // misclassified as parity errors and passed through uncorrected
+        let hamming = HammingECC::new();
+
+        for bit_pos in [0, 1, 2, 4, 8, 16, 32] {
+            hamming.reset_stats();
+            let test_data = 0x96A5_3C0F_F0C3_5A69u64;
+            let (encoded, parity) = hamming.encode(test_data);
+            let corrupted_data = encoded ^ (1u64 << bit_pos);
+
+            let result = hamming.decode(corrupted_data, parity);
+            assert!(result.is_ok(), "decode failed for bit {}", bit_pos);
+            let (decoded, syndrome) = result.unwrap();
+            assert_eq!(decoded, test_data, "failed to correct bit {}", bit_pos);
+            assert_eq!(syndrome.error_type, ECCError::SingleBit);
+            assert_eq!(syndrome.error_position, bit_pos as u8);
+
+            let (detected, corrected) = hamming.get_error_stats();
             assert_eq!(detected, 1);
+            assert_eq!(corrected, 1);
         }
+    }
+
+    #[test]
+    fn test_hamming_corrects_every_data_bit() {
+        let hamming = HammingECC::new();
+
+        for bit_pos in 0..64 {
+            let test_data = 0xDEAD_BEEF_CAFE_BABEu64;
+            let (encoded, parity) = hamming.encode(test_data);
+            let corrupted_data = encoded ^ (1u64 << bit_pos);
+
+            let (decoded, _) = hamming.decode(corrupted_data, parity).unwrap();
+            assert_eq!(decoded, test_data, "failed to correct bit {}", bit_pos);
+        }
+    }
+
+    #[test]
+    fn test_hamming_parity_bit_errors_leave_data_intact() {
+        let hamming = HammingECC::new();
+        let test_data = 0x0123_4567_89AB_CDEFu64;
+        let (encoded, parity) = hamming.encode(test_data);
+
+        // Flip each of the 8 parity-byte bits in turn: data must come back
+        // unmodified, flagged as a parity-byte error
+        for parity_bit in 0..8 {
+            let corrupted_parity = parity ^ (1u8 << parity_bit);
+
+            let result = hamming.decode(encoded, corrupted_parity);
+            assert!(result.is_ok(), "decode failed for parity bit {}", parity_bit);
+            let (decoded, syndrome) = result.unwrap();
+            assert_eq!(decoded, test_data);
+            assert_eq!(syndrome.error_type, ECCError::SingleBit);
+            assert_eq!(
+                syndrome.error_position,
+                PARITY_ERROR_POSITION_BASE + parity_bit
+            );
+        }
+    }
+
+    #[test]
+    fn test_hamming_double_bit_error_detected() {
+        let hamming = HammingECC::new();
+        let test_data = 0x5A5A_5A5A_5A5A_5A5Au64;
+        let (encoded, parity) = hamming.encode(test_data);
+
+        // Flip two data bits: SECDED must refuse to "correct"
+        let corrupted_data = encoded ^ (1u64 << 3) ^ (1u64 << 47);
+
+        let result = hamming.decode(corrupted_data, parity);
+        assert!(result.is_err());
     }
 }

--- a/src/fuse_manager.rs
+++ b/src/fuse_manager.rs
@@ -511,7 +511,7 @@ mod tests {
         let shadow_bank = manager.get_shadow_bank();
 
         // Shadow bank should be empty initially
-        assert_eq!(shadow_bank.count(), 0);
+        assert_eq!(shadow_bank.get_register_count(), 0);
     }
 
     #[test]
@@ -523,6 +523,6 @@ mod tests {
         let shadow_bank = manager.get_shadow_bank();
 
         // Shadow bank should have same count as fuses
-        assert_eq!(shadow_bank.count(), 2);
+        assert_eq!(shadow_bank.get_register_count(), 2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod shadow_runtime;
 // Re-export main cache coherency types
 pub use cache_coherency::{CacheLine, CacheState, L3Directory};
 pub use mmio::{CoherencyOp, MMIOCoherency};
-pub use runtime::{CoherencyRuntime, CoreCacheController};
+pub use runtime::{CoherencyRuntime, CoreCacheController, NUM_CORES};
 pub use state_machine::{CacheEvent, CoherencyStateMachine};
 
 // Re-export main shadow register types

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -68,6 +68,25 @@ pub enum CoherencyOp {
     Flush = 0x4,
 }
 
+/// Maximum spin iterations to wait for the busy bit before declaring the
+/// device hung; bounds the previously infinite busy-wait loops
+pub const MMIO_SPIN_TIMEOUT: u32 = 1_000_000;
+
+/// Spin until the device clears its busy bit, failing after MMIO_SPIN_TIMEOUT
+/// iterations so a stuck busy bit cannot hang the caller forever
+#[inline]
+unsafe fn wait_while_busy(reg: &CoherencyRegister) -> Result<(), ()> {
+    let mut spins = 0u32;
+    while reg.is_busy() {
+        if spins >= MMIO_SPIN_TIMEOUT {
+            return Err(());
+        }
+        spins += 1;
+        core::hint::spin_loop();
+    }
+    Ok(())
+}
+
 /// Real-Time MMIO Accessor
 pub struct MMIOCoherency {
     reg: *mut CoherencyRegister,
@@ -91,12 +110,8 @@ impl MMIOCoherency {
         reg.write_control(ctrl);
         reg.write_address(address);
 
-        // Spin until operation completes (real-time guarantee)
-        while reg.is_busy() {
-            core::hint::spin_loop();
-        }
-
-        Ok(())
+        // Bounded spin until operation completes
+        wait_while_busy(reg)
     }
 
     /// Execute cache write via MMIO (Step 3 from your flow)
@@ -109,12 +124,8 @@ impl MMIOCoherency {
         reg.write_control(ctrl);
         reg.write_address(address);
 
-        // Spin until invalidation completes
-        while reg.is_busy() {
-            core::hint::spin_loop();
-        }
-
-        Ok(())
+        // Bounded spin until invalidation completes
+        wait_while_busy(reg)
     }
 
     /// Invalidate cache line (Step 4 from your flow)
@@ -126,12 +137,8 @@ impl MMIOCoherency {
         reg.write_control(ctrl);
         reg.write_address(address);
 
-        // Real-time spin-wait
-        while reg.is_busy() {
-            core::hint::spin_loop();
-        }
-
-        Ok(())
+        // Bounded spin-wait
+        wait_while_busy(reg)
     }
 
     /// Read current cache state from hardware
@@ -158,6 +165,19 @@ mod tests {
             status: 0,
             data: [0; 16],
         })
+    }
+
+    #[test]
+    fn test_mmio_stuck_busy_bit_times_out() {
+        let mut reg = create_mock_register();
+        reg.status = 0x1; // busy bit never clears
+
+        unsafe {
+            let mut mmio = MMIOCoherency::new(&mut *reg as *mut CoherencyRegister as usize);
+            assert!(mmio.mmio_cache_read(0, 0x1000).is_err());
+            assert!(mmio.mmio_cache_write(0, 0x1000).is_err());
+            assert!(mmio.mmio_invalidate(0, 0x1000).is_err());
+        }
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,6 +6,9 @@ use crate::mmio::{MMIOCoherency, COHERENCY_CTL_BASE};
 use crate::state_machine::{CacheEvent, CoherencyStateMachine};
 use alloc::boxed::Box;
 
+/// Number of cores on the i9-12900K: 8 P-cores (0-7) + 8 E-cores (8-15)
+pub const NUM_CORES: usize = 16;
+
 /// Per-Core Cache Controller
 pub struct CoreCacheController {
     core_id: u8,
@@ -17,6 +20,13 @@ pub struct CoreCacheController {
 impl CoreCacheController {
     /// Initialize core cache controller
     pub unsafe fn new(core_id: u8) -> Self {
+        // The MMIO window below is sized for NUM_CORES controllers; an
+        // out-of-range id would produce a pointer outside that window
+        assert!(
+            (core_id as usize) < NUM_CORES,
+            "core_id out of range for i9-12900K (0-15)"
+        );
+
         const INIT: CacheLine = CacheLine::new();
         Self {
             core_id,
@@ -83,21 +93,22 @@ impl CoreCacheController {
 /// Multi-Core Coherency Runtime
 /// Demonstrates the complete 5-step flow from your example
 pub struct CoherencyRuntime {
-    cores: [Option<CoreCacheController>; 8],
+    cores: [Option<CoreCacheController>; NUM_CORES],
     l3_directory: L3Directory,
 }
 
 impl CoherencyRuntime {
     pub const fn new() -> Self {
+        const NONE: Option<CoreCacheController> = None;
         Self {
-            cores: [None, None, None, None, None, None, None, None],
+            cores: [NONE; NUM_CORES],
             l3_directory: L3Directory::new(),
         }
     }
 
-    /// Initialize core
+    /// Initialize core (P-cores 0-7, E-cores 8-15)
     pub unsafe fn init_core(&mut self, core_id: u8) {
-        if (core_id as usize) < 8 {
+        if (core_id as usize) < NUM_CORES {
             self.cores[core_id as usize] = Some(CoreCacheController::new(core_id));
         }
     }
@@ -139,7 +150,7 @@ pub unsafe extern "C" fn mmio_coherency_init() -> *mut CoherencyRuntime {
     let runtime = Box::leak(Box::new(CoherencyRuntime::new()));
 
     // Initialize all cores
-    for core_id in 0..8 {
+    for core_id in 0..NUM_CORES as u8 {
         runtime.init_core(core_id);
     }
 
@@ -261,7 +272,7 @@ mod tests {
         let runtime = create_mock_runtime();
 
         // All cores should be None initially
-        for i in 0..8 {
+        for i in 0..NUM_CORES {
             assert!(runtime.cores[i].is_none());
         }
     }
@@ -275,9 +286,9 @@ mod tests {
             runtime.init_core(0);
             assert!(runtime.cores[0].is_some());
 
-            // Initialize core 7 (boundary)
-            runtime.init_core(7);
-            assert!(runtime.cores[7].is_some());
+            // Initialize core 15 (boundary, last E-core)
+            runtime.init_core(15);
+            assert!(runtime.cores[15].is_some());
 
             // Initialize core 3
             runtime.init_core(3);
@@ -294,18 +305,18 @@ mod tests {
         unsafe {
             let mut runtime = create_mock_runtime();
 
-            // Try to initialize core 8 (out of bounds)
-            runtime.init_core(8);
+            // Try to initialize core 16 (out of bounds)
+            runtime.init_core(16);
 
             // Should not panic, but should do nothing
             // All cores should still be None
-            for i in 0..8 {
+            for i in 0..NUM_CORES {
                 assert!(runtime.cores[i].is_none());
             }
 
             // Try core 255
             runtime.init_core(255);
-            for i in 0..8 {
+            for i in 0..NUM_CORES {
                 assert!(runtime.cores[i].is_none());
             }
         }
@@ -316,17 +327,34 @@ mod tests {
         unsafe {
             let mut runtime = create_mock_runtime();
 
-            // Initialize all 8 cores
-            for core_id in 0..8 {
+            // Initialize all 16 cores (8 P-cores + 8 E-cores)
+            for core_id in 0..NUM_CORES as u8 {
                 runtime.init_core(core_id);
             }
 
             // Verify all cores are initialized
-            for i in 0..8 {
+            for i in 0..NUM_CORES {
                 assert!(runtime.cores[i].is_some());
                 if let Some(ref controller) = runtime.cores[i] {
                     assert_eq!(controller.core_id, i as u8);
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn test_coherency_runtime_supports_e_cores() {
+        unsafe {
+            let mut runtime = create_mock_runtime();
+
+            // Regression: E-core initialization (ids 8-15) used to be
+            // silently dropped while boot logs claimed 16 cores
+            for e_core in 8..16 {
+                runtime.init_core(e_core);
+            }
+
+            for i in 8..16 {
+                assert!(runtime.cores[i].is_some(), "E-core {} not initialized", i);
             }
         }
     }
@@ -359,8 +387,8 @@ mod tests {
             // Should return non-null pointer
             assert!(!runtime_ptr.is_null());
 
-            // All 8 cores should be initialized
-            for i in 0..8 {
+            // All 16 cores should be initialized
+            for i in 0..NUM_CORES {
                 assert!((*runtime_ptr).cores[i].is_some());
 
                 // Verify each core has correct ID

--- a/src/shadow_mmio.rs
+++ b/src/shadow_mmio.rs
@@ -7,9 +7,18 @@ use crate::sync_manager::{SyncDirection, SyncManager, SyncPolicy};
 use core::ptr::{read_volatile, write_volatile};
 
 /// MMIO Base Addresses for Shadow Register System
+///
+/// These are *physical* addresses. Kernels running with paging enabled must
+/// map them and use the mapped virtual address via
+/// `ShadowMMIOController::new_with_base` (e.g. baremetal-abi maps this region
+/// at its higher-half offset, see baremetal-abi/src/memory.rs SHADOW_REG_BASE).
 pub const SHADOW_REG_BASE: usize = 0x5000_0000;
 pub const FUSE_CTRL_BASE: usize = 0x5100_0000;
 pub const SYNC_CTRL_BASE: usize = 0x5200_0000;
+
+/// Maximum spin iterations to wait for command completion before declaring
+/// the device hung
+pub const MMIO_COMMAND_TIMEOUT: u32 = 1_000_000;
 
 /// Shadow Register MMIO Control Register
 #[repr(C)]
@@ -138,8 +147,13 @@ impl ShadowRegisterMMIO {
         // Write command
         self.write_control(ctrl);
 
-        // Wait for completion (spin-wait for real-time guarantee)
+        // Bounded spin-wait so a stuck busy bit cannot hang the caller
+        let mut spins = 0u32;
         while self.is_busy() {
+            if spins >= MMIO_COMMAND_TIMEOUT {
+                return Err("MMIO command timed out");
+            }
+            spins += 1;
             core::hint::spin_loop();
         }
 
@@ -165,101 +179,94 @@ pub struct ShadowMMIOController {
 }
 
 impl ShadowMMIOController {
-    /// Create a new MMIO controller
+    /// Create a new MMIO controller at the default physical base address
     pub unsafe fn new(
         shadow_bank: *mut ShadowRegisterBank,
         fuse_manager: *mut FuseManager,
     ) -> Self {
+        Self::new_with_base(SHADOW_REG_BASE, shadow_bank, fuse_manager)
+    }
+
+    /// Create a new MMIO controller at a caller-supplied base address
+    ///
+    /// Use this when the MMIO region is remapped (paging, simulation, tests).
+    /// Safety: `base` must point to a mapped ShadowRegisterMMIO block.
+    pub unsafe fn new_with_base(
+        base: usize,
+        shadow_bank: *mut ShadowRegisterBank,
+        fuse_manager: *mut FuseManager,
+    ) -> Self {
         Self {
-            mmio: SHADOW_REG_BASE as *mut ShadowRegisterMMIO,
+            mmio: base as *mut ShadowRegisterMMIO,
             shadow_bank,
             fuse_manager,
             sync_manager: SyncManager::new(),
         }
     }
 
+    /// Execute a single command against the MMIO block
+    #[inline]
+    unsafe fn exec(&mut self, command: MMIOCommand, register_id: u8) -> Result<(), &'static str> {
+        (&mut *self.mmio).execute_command(command, register_id)
+    }
+
     /// Read shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_read(&mut self, register_id: u8) -> Result<u64, &'static str> {
-        let mmio = &mut *self.mmio;
-
-        // Execute read command
-        mmio.execute_command(MMIOCommand::Read, register_id)?;
-
-        // Read data from MMIO
-        Ok(mmio.read_data())
+        self.exec(MMIOCommand::Read, register_id)?;
+        Ok((&*self.mmio).read_data())
     }
 
     /// Write shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_write(&mut self, register_id: u8, value: u64) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-
-        // Write data to MMIO
-        mmio.write_data(value);
-
-        // Execute write command
-        mmio.execute_command(MMIOCommand::Write, register_id)?;
-
-        Ok(())
+        (&mut *self.mmio).write_data(value);
+        self.exec(MMIOCommand::Write, register_id)
     }
 
     /// Commit shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_commit(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::Commit, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::Commit, register_id)
     }
 
     /// Rollback shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_rollback(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::Rollback, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::Rollback, register_id)
     }
 
     /// Lock shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_lock(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::Lock, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::Lock, register_id)
     }
 
     /// Unlock shadow register via MMIO
     #[inline]
     pub unsafe fn mmio_unlock(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::Unlock, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::Unlock, register_id)
     }
 
     /// Verify shadow register checksum via MMIO
     #[inline]
     pub unsafe fn mmio_verify(&mut self, register_id: u8) -> Result<bool, &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::Verify, register_id)?;
+        self.exec(MMIOCommand::Verify, register_id)?;
 
         // Check if verification passed (error bit should be clear)
-        Ok(!mmio.has_error())
+        Ok(!(&*self.mmio).has_error())
     }
 
     /// Load from fuse via MMIO
     #[inline]
     pub unsafe fn mmio_load_fuse(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::LoadFuse, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::LoadFuse, register_id)
     }
 
     /// Commit to fuse via MMIO
     #[inline]
     pub unsafe fn mmio_commit_fuse(&mut self, register_id: u8) -> Result<(), &'static str> {
-        let mmio = &mut *self.mmio;
-        mmio.execute_command(MMIOCommand::CommitFuse, register_id)?;
-        Ok(())
+        self.exec(MMIOCommand::CommitFuse, register_id)
     }
 
     /// Synchronize shadow register via MMIO
@@ -283,16 +290,22 @@ impl ShadowMMIOController {
         )
     }
 
-    /// Get register state via MMIO
+    /// Get the state reported by the MMIO status register
+    ///
+    /// The hardware exposes a single global status word that reflects the
+    /// most recently commanded register; there is no per-register query.
     #[inline]
-    pub unsafe fn mmio_get_state(&self, _register_id: u8) -> Result<RegisterState, &'static str> {
+    pub unsafe fn mmio_get_state(&self) -> Result<RegisterState, &'static str> {
         let mmio = &*self.mmio;
         Ok(mmio.get_state())
     }
 
-    /// Get register version via MMIO
+    /// Get the version reported by the MMIO status register
+    ///
+    /// As with `mmio_get_state`, this reflects the most recently commanded
+    /// register, not an arbitrary register ID.
     #[inline]
-    pub unsafe fn mmio_get_version(&self, _register_id: u8) -> Result<u8, &'static str> {
+    pub unsafe fn mmio_get_version(&self) -> Result<u8, &'static str> {
         let mmio = &*self.mmio;
         Ok(mmio.get_version())
     }

--- a/src/shadow_register.rs
+++ b/src/shadow_register.rs
@@ -34,6 +34,27 @@ impl From<u8> for RegisterState {
     }
 }
 
+/// Lookup table for the CRC32 (IEEE, reflected 0xEDB88320) byte step
+const CRC32_TABLE: [u32; 256] = {
+    let mut table = [0u32; 256];
+    let mut i = 0usize;
+    while i < 256 {
+        let mut crc = i as u32;
+        let mut bit = 0;
+        while bit < 8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB88320;
+            } else {
+                crc >>= 1;
+            }
+            bit += 1;
+        }
+        table[i] = crc;
+        i += 1;
+    }
+    table
+};
+
 /// Shadow Register - holds a copy of hardware fuse data
 #[repr(C, align(64))]
 pub struct ShadowRegister {
@@ -55,6 +76,8 @@ pub struct ShadowRegister {
     write_protected: bool,
     /// Backup value for rollback
     backup_value: u64,
+    /// Whether backup_value holds a real committed value
+    has_backup: bool,
 }
 
 impl ShadowRegister {
@@ -70,6 +93,7 @@ impl ShadowRegister {
             fuse_addr,
             write_protected: false,
             backup_value: 0,
+            has_backup: false,
         }
     }
 
@@ -116,6 +140,7 @@ impl ShadowRegister {
 
         // Backup current value for rollback
         self.backup_value = self.value.load(Ordering::Acquire);
+        self.has_backup = true;
 
         // Atomic commit
         let shadow_val = self.shadow_value.load(Ordering::Acquire);
@@ -134,6 +159,11 @@ impl ShadowRegister {
     /// Rollback to previous value
     #[inline]
     pub fn rollback(&mut self) -> Result<(), &'static str> {
+        // A rollback target only exists after a successful commit
+        if !self.has_backup {
+            return Err("No committed value to roll back to");
+        }
+
         // Restore backup value
         self.value.store(self.backup_value, Ordering::Release);
         self.shadow_value.store(self.backup_value, Ordering::Release);
@@ -142,8 +172,10 @@ impl ShadowRegister {
         let crc = self.calculate_crc32(self.backup_value);
         self.checksum.store(crc, Ordering::Release);
 
-        // Decrement version
-        self.version.fetch_sub(1, Ordering::AcqRel);
+        // Decrement version, saturating at 0 so it cannot wrap to u32::MAX
+        let _ = self
+            .version
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |v| v.checked_sub(1));
 
         // Update state
         self.state.store(RegisterState::Committed as u32, Ordering::Release);
@@ -187,25 +219,31 @@ impl ShadowRegister {
         self.version.load(Ordering::Acquire)
     }
 
-    /// Calculate CRC32 checksum
+    /// Calculate CRC32 checksum (table-driven; called on every commit)
     #[inline]
     fn calculate_crc32(&self, value: u64) -> u32 {
-        // Simple CRC32 implementation
         let mut crc: u32 = 0xFFFFFFFF;
-        let bytes = value.to_le_bytes();
 
-        for byte in bytes.iter() {
-            crc ^= *byte as u32;
-            for _ in 0..8 {
-                if (crc & 1) != 0 {
-                    crc = (crc >> 1) ^ 0xEDB88320;
-                } else {
-                    crc >>= 1;
-                }
-            }
+        for byte in value.to_le_bytes() {
+            let index = ((crc ^ byte as u32) & 0xFF) as usize;
+            crc = (crc >> 8) ^ CRC32_TABLE[index];
         }
 
         !crc
+    }
+
+    /// Check a candidate value against the stored checksum
+    #[inline]
+    pub fn verify_value(&self, value: u64) -> bool {
+        self.checksum.load(Ordering::Acquire) == self.calculate_crc32(value)
+    }
+
+    /// Test-only: flip bits of the active value, simulating storage corruption
+    /// without touching the stored checksum or ECC parity
+    #[cfg(test)]
+    pub(crate) fn corrupt_value_for_test(&self, mask: u64) {
+        let v = self.value.load(Ordering::Acquire);
+        self.value.store(v ^ mask, Ordering::Release);
     }
 
     /// Get fuse address
@@ -257,18 +295,27 @@ impl ShadowRegisterBank {
         self.count
     }
 
-    /// Get register by ID
-    pub fn get_register(&self, id: u32) -> Option<&ShadowRegister> {
+    /// Get the bank index holding the register with the given ID
+    pub fn index_of(&self, id: u32) -> Option<usize> {
+        // Fast path: IDs commonly match their insertion index
+        let idx = id as usize;
+        if idx < self.count && self.registers[idx].get_id() == id {
+            return Some(idx);
+        }
+
         self.registers[..self.count]
             .iter()
-            .find(|reg| reg.get_id() == id)
+            .position(|reg| reg.get_id() == id)
+    }
+
+    /// Get register by ID
+    pub fn get_register(&self, id: u32) -> Option<&ShadowRegister> {
+        self.index_of(id).map(|idx| &self.registers[idx])
     }
 
     /// Get mutable register by ID
     pub fn get_register_mut(&mut self, id: u32) -> Option<&mut ShadowRegister> {
-        self.registers[..self.count]
-            .iter_mut()
-            .find(|reg| reg.get_id() == id)
+        self.index_of(id).map(move |idx| &mut self.registers[idx])
     }
 
     /// Get register by index
@@ -310,12 +357,6 @@ impl ShadowRegisterBank {
         }
 
         Ok(committed)
-    }
-
-    /// Get count of active registers
-    #[inline(always)]
-    pub fn count(&self) -> usize {
-        self.count
     }
 }
 
@@ -386,6 +427,33 @@ mod tests {
     }
 
     #[test]
+    fn test_shadow_register_rollback_without_commit_fails() {
+        let mut reg = ShadowRegister::new(1, 0x1000);
+
+        // No commit has ever happened: rollback must not silently restore 0
+        reg.write(0x1234).unwrap();
+        assert!(reg.rollback().is_err());
+
+        // The staged write and version are untouched by the failed rollback
+        assert_eq!(reg.get_version(), 1);
+    }
+
+    #[test]
+    fn test_shadow_register_rollback_version_saturates_at_zero() {
+        let mut reg = ShadowRegister::new(1, 0x1000);
+
+        reg.write(0x1).unwrap();
+        reg.commit().unwrap();
+        assert_eq!(reg.get_version(), 1);
+
+        // First rollback brings version to 0; further rollbacks must not wrap
+        reg.rollback().unwrap();
+        assert_eq!(reg.get_version(), 0);
+        reg.rollback().unwrap();
+        assert_eq!(reg.get_version(), 0);
+    }
+
+    #[test]
     fn test_shadow_register_lock() {
         let mut reg = ShadowRegister::new(1, 0x1000);
         reg.write(0x5555).unwrap();
@@ -426,7 +494,7 @@ mod tests {
     #[test]
     fn test_shadow_register_bank_initialization() {
         let bank = ShadowRegisterBank::new();
-        assert_eq!(bank.count(), 0);
+        assert_eq!(bank.get_register_count(), 0);
     }
 
     #[test]
@@ -435,11 +503,11 @@ mod tests {
 
         // Add first register
         assert!(bank.add_register(1, 0x1000).is_ok());
-        assert_eq!(bank.count(), 1);
+        assert_eq!(bank.get_register_count(), 1);
 
         // Add second register
         assert!(bank.add_register(2, 0x2000).is_ok());
-        assert_eq!(bank.count(), 2);
+        assert_eq!(bank.get_register_count(), 2);
 
         // Check we can retrieve them
         assert!(bank.get_register(1).is_some());

--- a/src/shadow_runtime.rs
+++ b/src/shadow_runtime.rs
@@ -18,6 +18,8 @@ pub struct ShadowRegisterRuntime {
     sync_manager: SyncManager,
     /// ECC manager
     ecc_manager: ECCManager,
+    /// Hamming parity for each register's committed value, indexed like the bank
+    ecc_parity: [u8; 256],
     /// MMIO controller
     mmio_controller: Option<ShadowMMIOController>,
 }
@@ -30,6 +32,7 @@ impl ShadowRegisterRuntime {
             fuse_manager: FuseManager::new(),
             sync_manager: SyncManager::new(),
             ecc_manager: ECCManager::new(ECCStrategy::Hamming),
+            ecc_parity: [0; 256],
             mmio_controller: None,
         }
     }
@@ -68,42 +71,53 @@ impl ShadowRegisterRuntime {
         self.fuse_manager.commit_all()
     }
 
-    /// Read a shadow register
+    /// Read a shadow register, correcting single-bit corruption via ECC
     pub fn read(&self, register_id: u32) -> Result<u64, &'static str> {
-        if let Some(reg) = self.shadow_bank.get_register(register_id) {
-            // Verify integrity
-            if !reg.verify() {
-                return Err("Register checksum verification failed");
-            }
+        let index = self
+            .shadow_bank
+            .index_of(register_id)
+            .ok_or("Register not found")?;
+        let reg = self.shadow_bank.get_by_index(index).ok_or("Register not found")?;
 
-            Ok(reg.read())
-        } else {
-            Err("Register not found")
+        // ECC decode first: a single flipped bit is repaired here, double-bit
+        // and worse are rejected
+        let raw = reg.read();
+        let (value, _syndrome) = self.ecc_manager.decode_u64(raw, self.ecc_parity[index])?;
+
+        // Verify the (possibly corrected) value against the stored checksum
+        if !reg.verify_value(value) {
+            return Err("Register checksum verification failed");
         }
+
+        Ok(value)
     }
 
     /// Write to a shadow register
     pub fn write(&mut self, register_id: u32, value: u64) -> Result<(), &'static str> {
         if let Some(reg) = self.shadow_bank.get_register_mut(register_id) {
-            // Encode with ECC
-            let (_encoded_value, _ecc) = self.ecc_manager.encode_u64(value);
-
-            // Write to register
-            reg.write(value)?;
-
-            Ok(())
+            reg.write(value)
         } else {
             Err("Register not found")
         }
     }
 
-    /// Commit a shadow register
+    /// Commit a shadow register and record ECC parity for the committed value
     pub fn commit(&mut self, register_id: u32) -> Result<(), &'static str> {
-        if let Some(reg) = self.shadow_bank.get_register_mut(register_id) {
-            reg.commit()
-        } else {
-            Err("Register not found")
-        }
+        let index = self
+            .shadow_bank
+            .index_of(register_id)
+            .ok_or("Register not found")?;
+        let reg = self
+            .shadow_bank
+            .get_by_index_mut(index)
+            .ok_or("Register not found")?;
+
+        reg.commit()?;
+
+        let (_, parity) = self.ecc_manager.encode_u64(reg.read());
+        self.ecc_parity[index] = parity;
+
+        Ok(())
     }
 
     /// Synchronize registers with fuses
@@ -453,6 +467,47 @@ mod tests {
         let result = runtime.read(1);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0x12345678);
+    }
+
+    /// Test: ECC corrects a single flipped bit in the stored value
+    #[test]
+    fn test_shadow_register_runtime_read_corrects_single_bit_flip() {
+        let mut runtime = ShadowRegisterRuntime::new();
+
+        runtime.register_fuse(1, 0x1000, FuseMode::MTP).unwrap();
+        runtime.write(1, 0xCAFE_BABE_DEAD_BEEF).unwrap();
+        runtime.commit(1).unwrap();
+
+        // Flip one bit of the committed value behind the runtime's back
+        runtime
+            .shadow_bank
+            .get_register(1)
+            .unwrap()
+            .corrupt_value_for_test(1u64 << 42);
+
+        // Read repairs the corruption and reports it in the ECC stats
+        assert_eq!(runtime.read(1).unwrap(), 0xCAFE_BABE_DEAD_BEEF);
+        let (detected, corrected) = runtime.get_ecc_stats();
+        assert_eq!(detected, 1);
+        assert_eq!(corrected, 1);
+    }
+
+    /// Test: ECC rejects double-bit corruption instead of mis-correcting
+    #[test]
+    fn test_shadow_register_runtime_read_rejects_double_bit_flip() {
+        let mut runtime = ShadowRegisterRuntime::new();
+
+        runtime.register_fuse(1, 0x1000, FuseMode::MTP).unwrap();
+        runtime.write(1, 0x1234_5678).unwrap();
+        runtime.commit(1).unwrap();
+
+        runtime
+            .shadow_bank
+            .get_register(1)
+            .unwrap()
+            .corrupt_value_for_test((1u64 << 3) | (1u64 << 57));
+
+        assert!(runtime.read(1).is_err());
     }
 
     /// Test: Read from non-existent register

--- a/src/version_control.rs
+++ b/src/version_control.rs
@@ -307,16 +307,18 @@ impl VersionedShadowRegister {
         Some((entry1.get_value(), entry2.get_value()))
     }
 
-    /// Get all version numbers
+    /// Get all version numbers (newest first)
     pub fn get_all_versions(&self) -> Vec<u32> {
-        let count = self.history.count();
+        // Snapshot head/count once instead of reloading them per entry
+        let count = self.history.count.load(Ordering::Acquire) as usize;
+        let head = self.history.head.load(Ordering::Acquire) as usize;
         let mut versions = Vec::with_capacity(count);
 
         for i in 0..count {
-            if let Some(entry) = self.history.get_by_offset(i) {
-                if entry.is_valid() {
-                    versions.push(entry.get_version());
-                }
+            let index = (head + MAX_VERSION_HISTORY - 1 - i) % MAX_VERSION_HISTORY;
+            let entry = &self.history.entries[index];
+            if entry.is_valid() {
+                versions.push(entry.get_version());
             }
         }
 


### PR DESCRIPTION
Full-codebase code review (7 finder angles, ~38 candidates, per-candidate verification) followed by fixes for the confirmed findings. Owner decisions honored: 16-core support, real ECC wiring, and an honest global-status contract for the MMIO state/version queries.

## Correctness fixes

- **ecc_handler — Hamming decode could not correct power-of-two bit positions.** Any syndrome with a single set bit was classified as "parity error, no correction needed", so single-bit data errors at bits 1, 2, 4, 8, 16, 32 passed through uncorrected (existing tests only covered positions whose syndromes have multiple bits set). Rewritten as a proper SECDED(72,64) code: parity bits occupy power-of-two codeword positions, an overall parity bit distinguishes single- from double-bit errors, and encode is O(8) mask+popcount instead of 512 loop iterations.
- **runtime — E-cores 8–15 were silently dropped.** `init_core` no-opped for `core_id >= 8` while `boot.rs`, `bin/minimal.rs`, and the README initialize 0..16 and log "16 cores initialized". The runtime now holds all 16 i9-12900K cores (8P+8E), and `CoreCacheController::new` asserts the core-id range its MMIO window is derived from.
- **shadow_runtime — ECC was a no-op.** The write path computed `encode_u64` into discarded bindings and reads never verified parity. Parity is now recorded per register at commit and decoded on read: single-bit corruption is repaired (and counted in the ECC stats), double-bit corruption is rejected.
- **shadow_register — rollback hazards.** `rollback()` before any commit silently restored the default 0; it now errors. The version counter saturates at 0 instead of wrapping to `u32::MAX` (which also poisoned the sync manager's `version > 0` conflict heuristic).
- **mmio / shadow_mmio — infinite busy-waits.** All spin loops are now bounded (`MMIO_SPIN_TIMEOUT`, `MMIO_COMMAND_TIMEOUT`) so a stuck busy bit returns an error instead of hanging the caller forever.
- **cache_coherency — direct-mapped aliasing corrupted MESI state.** The `tag` field existed but was never compared; two addresses mapping to the same index shared one line's state/ref_count/data. Accesses now compare the tag and evict on alias collision.
- **boot — coherency runtime was built then dropped.** `init_cache_coherency()` initialized 16 cores into a local that fell out of scope. The runtime now lives in a static with an accessor (`boot::coherency_runtime()`).

## API / cleanup

- `mmio_get_state` / `mmio_get_version` drop their ignored `register_id` parameter — the hardware status word is global (reflects the last commanded register), and the old signature implied per-register queries it never performed. Added `ShadowMMIOController::new_with_base` for remapped MMIO regions and collapsed six copy-paste command wrappers into one helper.
- baremetal-abi: the COM1 UART driver duplicated between `boot.rs` and `bin/minimal.rs` is now one shared `serial` module (with a bounded TX-ready wait); the previously undeclared `serial` feature is declared.
- shadow_register: table-driven CRC32 (was bit-by-bit on every commit), id→index fast path for register lookup (kills the O(n²) sync loops), removed the duplicate `count()` accessor.
- version_control: `get_all_versions` snapshots head/count once instead of reloading atomics per entry.

## Testing

- `cargo test`: **186 passed** (175 before). New regression tests: ECC correction at every data bit incl. power-of-two positions, parity-byte errors leaving data intact, double-bit rejection, rollback-before-commit and version saturation, ECC repair/reject through the runtime, alias eviction, E-core init, and MMIO timeout paths.
- baremetal-abi type-checks clean for the library and `minimal-kernel` binary.

## Pre-existing issue (not addressed here)

`cargo build` for the custom `x86_64-i9-12900k.json` target fails on the unmodified tree as well: the `bootloader = "0.11"` dependency pulls std-dependent crates that cannot compile for the no_std target (and its build script panics). In the bootloader 0.11 workflow the kernel normally depends only on `bootloader_api`, with the disk-image builder depending on `bootloader` from a separate host crate — left untouched pending a decision.

Also flagged during review but intentionally left for owner decision: the `compiler_fence()` simulation stubs in `cache_coherency::core_write` (`broadcast_invalidate`/`writeback_and_acquire`), the ECC-skip for fuses with `redundancy <= 1`, the one-sided version heuristic in bidirectional sync, and `InitializeOnly` returning `Ok(())` on skip.

https://claude.ai/code/session_01878M6en5s6bbe8ER8FExdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01878M6en5s6bbe8ER8FExdm)_